### PR TITLE
Use example.com for fixture email

### DIFF
--- a/src/builder-functions.js
+++ b/src/builder-functions.js
@@ -36,7 +36,7 @@ String.prototype.asEmail = function(){
   return function(incrementer){
     return{
       name:fieldName,
-      value: "email"+incrementer+"@email.com"
+      value: "email"+incrementer+"@example.com"
     };
   };
 };


### PR DESCRIPTION
- Now Register.com has `email.com`. If someone buy the domain, they can get the mail from generated address.
- IANA provides `example.com` for documentation purpose. But sometimes we can use it for testing purpose. https://en.wikipedia.org/wiki/Example.com